### PR TITLE
Add basic green & white website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# pointage
+# Pointage
+
+Ce dépôt contient un exemple de site web pour une entreprise de gestion de temps de présence.
+
+Ouvrez `index.html` dans votre navigateur pour découvrir la page de démonstration.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestion de temps de présence</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Entreprise de Gestion de Temps</h1>
+    <p>Suivez la présence de vos équipes efficacement</p>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Simplicité et efficacité</h2>
+      <p>Notre solution permet de suivre les heures de présence de vos employés en toute simplicité.</p>
+    </section>
+    <section class="features">
+      <h3>Fonctionnalités</h3>
+      <ul>
+        <li>Pointage en temps réel</li>
+        <li>Rapports détaillés</li>
+        <li>Accès sécurisé</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 Gestion de Temps. Tous droits réservés.</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,39 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #fff;
+  color: #333;
+}
+
+header {
+  background-color: #2ecc71;
+  color: #fff;
+  padding: 20px;
+  text-align: center;
+}
+
+.hero {
+  background-color: #ecf9f1;
+  padding: 40px;
+  text-align: center;
+}
+
+.features h3 {
+  color: #2ecc71;
+}
+
+.features ul {
+  list-style: none;
+  padding: 0;
+}
+
+.features li {
+  margin: 10px 0;
+}
+
+footer {
+  background-color: #2ecc71;
+  color: #fff;
+  text-align: center;
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
- add an index page in French for the presence management company
- style the page with a green and white color scheme
- document how to view the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687e560404e48328bdf488e2b70797de